### PR TITLE
Add configuration for the platformio build system.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = atmelavr
+board = pro8MHzatmega168
+framework = arduino
+monitor_speed=115200
+lib_deps =
+  SimpleTimer
+  TinyGPS
+  https://github.com/billygr/LibAPRS
+


### PR DESCRIPTION
Hi,

I added a platformio configuration for this project. It allows you to build the project from the command line without having to configure a bunch of options in the Arduino IDE. All settings (including libraries that it depends on) are specified in the platformio configuration file.

PlatformIO usage examples:
* to compile (and automatically install dependences): pio run
* to compile and upload: pio run -t upload
* to watch serial communication: pio device monitor

PlatformIO itself can be installed as follows (Linux example):
* sudo apt-get install python-pip
* sudo pip install platformio